### PR TITLE
feat: add weETH support to TVL calculations for base, arbitrum, and b…

### DIFF
--- a/projects/DESK/index.js
+++ b/projects/DESK/index.js
@@ -5,6 +5,7 @@ async function baseTvl(api) {
     [ADDRESSES.base.USDC, "0x395c7f20bc6f38dfc644aa1a4023dc47d6939481"], // Vault
     [ADDRESSES.base.cbBTC, "0x395c7f20bc6f38dfc644aa1a4023dc47d6939481"], // Vault
     [ADDRESSES.base.WETH, "0x395c7f20bc6f38dfc644aa1a4023dc47d6939481"], // Vault
+    [ADDRESSES.base.weETH, "0x395c7f20bc6f38dfc644aa1a4023dc47d6939481"], // Vault
   ];
   return sumTokens2({ api, tokensAndOwners });
 }
@@ -12,6 +13,7 @@ async function baseTvl(api) {
 async function arbitrumTvl(api) {
   const tokensAndOwners = [
     [ADDRESSES.arbitrum.USDC_CIRCLE, "0x255659CaC93868AAf7AFcfB3F862AC300E3697B4"], // Vault
+    [ADDRESSES.arbitrum.weETH, "0x255659CaC93868AAf7AFcfB3F862AC300E3697B4"], // Vault
   ];
   return sumTokens2({ api, tokensAndOwners });
 }
@@ -19,6 +21,7 @@ async function arbitrumTvl(api) {
 async function bscTvl(api) {
   const tokensAndOwners = [
     [ADDRESSES.bsc.USDC, "0x6388E83ed0808F3bd0744bB38AA8ecf5dA4C0D8F"], // Vault
+    [ADDRESSES.bsc.weETH, "0x6388E83ed0808F3bd0744bB38AA8ecf5dA4C0D8F"], // Vault
   ];
   return sumTokens2({ api, tokensAndOwners });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the weETH token on Base, Arbitrum, and BSC networks, allowing balances for this token to be tracked on these chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->